### PR TITLE
Update test_suites_369/*.yml test suites to use tag-based exclusions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY dev-requirements.txt /dev-requirements.txt
 COPY components /components
 RUN apt-get update && \
     apt-get install -y git python2.7 python-pip gcc libcurl4-openssl-dev libssl-dev wget && \
-    git clone --depth 1 --branch r3.6.9 https://github.com/mongodb/mongo && \
+    git clone --depth 1 --branch v3.6.9-dbaas-testing https://github.com/mongodb/mongo.git && \
     pip install --user -r /dev-requirements.txt && \
     cp /test_suites_369/* /mongo/buildscripts/resmokeconfig/suites && \
     wget https://downloads.mongodb.org/linux/mongodb-shell-linux-x86_64-debian92-3.6.9.tgz && \

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ sudo usermod -a -G docker ubuntu
  * Then run this script.
 
 ```sh
-git clone https://github.com/10gen/MongoDB_Tests.git
-cd MongoDB_Tests
+git clone https://github.com/mongodb-developer/service-tests.git
+cd ./service-tests
 ./0_docker-build.sh
 ./1_docker-run.sh 'mongodb://<USER>:<PASSWORD>@documentdb-tests.cluster-c23gwlgcxzrp.eu-west-1.docdb.amazonaws.com:27017/?replicaSet=rs0&ssl=true'
 ./2_docker-collect-logs-rm.sh
@@ -196,9 +196,8 @@ After digesting the results and finding the more interesting failures, we can lo
 ### 1. Clone MongoDB repository and check out version
 The version checked out is the default version we tested with.
 ```
-$ git clone https://github.com/mongodb/mongo
+$ git clone --branch=v3.6.9-dbaas-testing https://github.com/mongodb/mongo.git
 $ cd ./mongo
-$ git checkout v3.6.9
 ```
 
 ### 2. Identify and run test

--- a/test_suites_369/dbaas_aggregation.yml
+++ b/test_suites_369/dbaas_aggregation.yml
@@ -6,39 +6,27 @@ selector:
   exclude_files:
   - jstests/aggregation/extras/*.js
   - jstests/aggregation/data/*.js
-  - jstests/aggregation/bugs/cursor_timeout.js
-  - jstests/aggregation/bugs/lookup_unwind_getmore.js
-  - jstests/aggregation/bugs/lookup_unwind_killcursor.js
-  - jstests/aggregation/bugs/server3253.js
-  - jstests/aggregation/expressions/arrayToObject.js
-  # 3.6 tests to exclude
-  - jstests/aggregation/bugs/server6179.js
-  - jstests/aggregation/bugs/server6179.js
-  - jstests/aggregation/bugs/server7781.js
-  - jstests/aggregation/mongos_merge.js
-  - jstests/aggregation/mongos_slaveok.js
-  - jstests/aggregation/shard_targeting.js
-  - jstests/aggregation/sources/addFields/use_cases.js
-  - jstests/aggregation/sources/addFields/weather.js
-  - jstests/aggregation/sources/collStats/shard_host_info.js
-  - jstests/aggregation/sources/facet/use_cases.js
-  - jstests/aggregation/sources/graphLookup/sharded.js
-  - jstests/aggregation/sources/lookup/lookup.js
-  - jstests/aggregation/sources/replaceRoot/address.js
-  - jstests/aggregation/testshard1.js
-  - jstests/aggregation/testSlave.js
   exclude_with_any_tags:
-  - requires_replication
-  - requires_sharding
+  # Tests that aren't testing specific behaviors of authentication or authorization assume they are
+  # only ever being run with the __system user, which may not be compatible with the more
+  # restrictive permissions of a Database as a Service offering.
+  # https://docs.atlas.mongodb.com/reference/unsupported-commands-paid-tier-clusters/
+  - assumes_superuser_permissions
+  # The eval command is deprecated and isn't expected to be supported by Database as a Service
+  # offerings.
+  - requires_eval_command
+  # Tests that start their own MongoDB clusters using MongoRunner, ReplSetTest, or ShardingTest
+  # aren't meaningfully exercising anything about the Database as a Service offering.
+  - requires_spawning_own_processes
+  # Using the .host property of a Mongo connection object to establish a separate connection leads
+  # to omitting the auth+TLS connection string options.
+  - uses_multiple_connections
+  # Certains commands are only available when the testing mode of the server
+  # (`--setParameter enableTestCommands=1`) is enabled.
+  - uses_testing_only_commands
+
 executor:
-  archive:
-    hooks:
   config:
     shell_options:
       readMode: commands
-  hooks:
-  fixture:
-    class: MongoDFixture
-    mongod_options:
-      set_parameters:
-        enableTestCommands: 1
+      ssl: ''

--- a/test_suites_369/dbaas_change_streams.yml
+++ b/test_suites_369/dbaas_change_streams.yml
@@ -3,12 +3,6 @@ test_kind: js_test
 selector:
   roots:
   - jstests/change_streams/**/*.js
-  exclude_files:
-  - jstests/change_streams/change_stream.js
-  - jstests/change_streams/invalid_namespaces.js
-  - jstests/change_streams/lookup_post_image.js
-  - jstests/change_streams/lookup_post_image_resume_after.js
-  - jstests/change_streams/only_wake_getmore_for_relevant_changes.js
   exclude_with_any_tags:
   ##
   # The next tags correspond to the special errors thrown by the
@@ -22,26 +16,30 @@ selector:
   # "Cowardly refusing to run test with overridden write concern when it uses a command that can
   #  only perform w=1 writes: ..."
   - requires_eval_command
-  - requires_replication
-  - requires_sharding
+  # Tests that aren't testing specific behaviors of authentication or authorization assume they are
+  # only ever being run with the __system user, which may not be compatible with the more
+  # restrictive permissions of a Database as a Service offering.
+  # https://docs.atlas.mongodb.com/reference/unsupported-commands-paid-tier-clusters/
+  - assumes_superuser_permissions
+  # Tests that start their own MongoDB clusters using MongoRunner, ReplSetTest, or ShardingTest
+  # aren't meaningfully exercising anything about the Database as a Service offering.
+  - requires_spawning_own_processes
+  # Using the .host property of a Mongo connection object to establish a separate connection leads
+  # to omitting the auth+TLS connection string options.
+  - uses_multiple_connections
+  # Certains commands are only available when the testing mode of the server
+  # (`--setParameter enableTestCommands=1`) is enabled.
+  - uses_testing_only_commands
 
 executor:
-  archive:
-    hooks:
   config:
     shell_options:
       global_vars:
         TestData:
           defaultReadConcernLevel: majority
           enableMajorityReadConcern: ''
-      eval: "var testingReplication = true; load('jstests/libs/override_methods/set_read_and_write_concerns.js');"
+      eval: >-
+        var testingReplication = true;
+        load('jstests/libs/override_methods/set_read_and_write_concerns.js');
       readMode: commands
-  hooks:
-  fixture:
-    class: ReplicaSetFixture
-    mongod_options:
-      bind_ip_all: ''
-      set_parameters:
-        enableTestCommands: 1
-        numInitialSyncAttempts: 1
-    num_nodes: 1
+      ssl: ''

--- a/test_suites_369/dbaas_core.yml
+++ b/test_suites_369/dbaas_core.yml
@@ -8,137 +8,40 @@ selector:
   # Transactions are not supported on MongoDB standalone nodes, so we do not run these tests in the
   # 'core' suite. Instead we run them against a 1-node replica set in the 'core_txns' suite.
   - jstests/core/txns/**/*.js
-  - jstests/core/apply_ops1.js
-  - jstests/core/apply_ops_atomicity.js
-  - jstests/core/auth1.js
-  - jstests/core/auth_copydb.js
-  - jstests/core/automation_setparameter.js
-  - jstests/core/awaitdata_getmore_cmd.js
-  - jstests/core/bench_test1.js
-  - jstests/core/bench_test2.js
-  - jstests/core/bench_test3.js
-  - jstests/core/bypass_doc_validation.js
-  - jstests/core/capped6.js
-  - jstests/core/capped_empty.js
-  - jstests/core/capped_update.js
-  - jstests/core/collation.js
-  - jstests/core/collection_truncate.js
-  - jstests/core/commands_namespace_parsing.js
+  # The find command fails with a different error message than the one expected when given a
+  # non-string collection name argument.
   - jstests/core/commands_with_uuid.js
-  - jstests/core/compact_keeps_indexes.js
-  - jstests/core/connection_status.js
-  - jstests/core/connection_string_validation.js
-  - jstests/core/constructors.js
-  - jstests/core/count10.js
-  - jstests/core/count_plan_summary.js
-  - jstests/core/create_indexes.js
-  - jstests/core/currentop.js
-  - jstests/core/cursora.js
+  # dbadmin.js is timing-sensitive when reporting whether there is clock skew.
   - jstests/core/dbadmin.js
-  - jstests/core/dbhash.js
-  - jstests/core/dbhash2.js
-  - jstests/core/distinct3.js
-  - jstests/core/dropdb_race.js
-  - jstests/core/elemmatch_or_pushdown.js
-  - jstests/core/eval0.js
-  - jstests/core/eval1.js
-  - jstests/core/eval3.js
-  - jstests/core/eval4.js
-  - jstests/core/eval5.js
-  - jstests/core/eval6.js
-  - jstests/core/eval7.js
-  - jstests/core/eval9.js
-  - jstests/core/eval_mr.js
-  - jstests/core/eval_nolock.js
-  - jstests/core/evala.js
-  - jstests/core/evalb.js
-  - jstests/core/evald.js
-  - jstests/core/evale.js
-  - jstests/core/evalg.js
-  - jstests/core/evalh.js
-  - jstests/core/evalj.js
+  # These test run commands using legacy queries, which are not supported on sessions.
   - jstests/core/exhaust.js
-  - jstests/core/explain_shell_helpers.js
-  - jstests/core/find_and_modify_concurrent_update.js
-  - jstests/core/fsync.js
-  - jstests/core/geo_update_btree.js
-  - jstests/core/geo_update_btree2.js
-  - jstests/core/index9.js
-  - jstests/core/index_bigkeys_nofail.js
-  - jstests/core/index_bigkeys_validation.js
-  - jstests/core/index_id_options.js
-  - jstests/core/indexes_on_indexes.js
-  - jstests/core/insert2.js
-  - jstests/core/views/invalid_system_views.js
-  - jstests/core/ismaster.js
-  - jstests/core/js3.js
-  - jstests/core/js7.js
-  - jstests/core/js9.js
-  - jstests/core/json_schema/misc_validation.js
-  - jstests/core/kill_cursors.js
-  - jstests/core/killop_drop_collection.js
-  - jstests/core/list_all_local_cursors.js
-  - jstests/core/list_all_local_sessions.js
-  - jstests/core/list_all_sessions.js
-  - jstests/core/list_collections_no_views.js
-  - jstests/core/list_indexes.js
-  - jstests/core/list_sessions.js
-  - jstests/core/loadserverscripts.js
-  - jstests/core/logprocessdetails.js
-  - jstests/core/max_time_ms.js
-  - jstests/core/mr_killop.js
-  - jstests/core/notablescan.js
-  - jstests/core/opcounters_write_cmd.js
-  - jstests/core/profile1.js
-  - jstests/core/profile3.js
-  - jstests/core/queryoptimizer3.js
-  - jstests/core/queryoptimizera.js
-  - jstests/core/read_after_optime.js
-  - jstests/core/recursion.js
-  - jstests/core/remove8.js
-  - jstests/core/remove9.js
-  - jstests/core/removeb.js
-  - jstests/core/removec.js
-  - jstests/core/rename8.js
-  - jstests/core/role_management_helpers.js
-  - jstests/core/set_param1.js
-  - jstests/core/shell_connection_strings.js
-  - jstests/core/shellstartparallel.js
-  - jstests/core/splitvector.js
-  - jstests/core/stages_and_hash.js
-  - jstests/core/stages_and_sorted.js
-  - jstests/core/stages_collection_scan.js
-  - jstests/core/stages_delete.js
-  - jstests/core/stages_fetch.js
-  - jstests/core/stages_ixscan.js
-  - jstests/core/stages_limit_skip.js
-  - jstests/core/stages_mergesort.js
-  - jstests/core/stages_or.js
-  - jstests/core/stages_text.js
-  - jstests/core/storefunc.js
-  - jstests/core/updatef.js
-  - jstests/core/user_management_helpers.js
   - jstests/core/validate_cmd_ns.js
-  - jstests/core/validate_user_documents.js
-  - jstests/core/views/duplicate_ns.js
-  - jstests/core/views/views_all_commands.js
-  - jstests/core/views/views_change.js
-  - jstests/core/views/views_creation.js
-  - jstests/core/views/views_drop.js
-  - jstests/core/views/views_rename.js
+  # Causal consistency is enabled when the retryWrites options is specified in the connection
+  # string. This leads to afterClusterTime being specified as a readConcern option, which conflicts
+  # with afterOpTime being specified as a readConcern option by the test.
+  - jstests/core/read_after_optime.js
   exclude_with_any_tags:
-  - requires_replication
-  - requires_sharding
+  # Tests that aren't testing specific behaviors of authentication or authorization assume they are
+  # only ever being run with the __system user, which may not be compatible with the more
+  # restrictive permissions of a Database as a Service offering.
+  # https://docs.atlas.mongodb.com/reference/unsupported-commands-paid-tier-clusters/
+  - assumes_superuser_permissions
+  # The eval command is deprecated and isn't expected to be supported by Database as a Service
+  # offerings.
+  - requires_eval_command
+  # Tests that start their own MongoDB clusters using MongoRunner, ReplSetTest, or ShardingTest
+  # aren't meaningfully exercising anything about the Database as a Service offering.
+  - requires_spawning_own_processes
+  # Using the .host property of a Mongo connection object to establish a separate connection leads
+  # to omitting the auth+TLS connection string options.
+  - uses_multiple_connections
+  # Certains commands are only available when the testing mode of the server
+  # (`--setParameter enableTestCommands=1`) is enabled.
+  - uses_testing_only_commands
+
 executor:
-  archive:
-    hooks:
   config:
     shell_options:
+      eval: var testingReplication = true;
       readMode: commands
-      eval: load("jstests/libs/override_methods/detect_spawning_own_mongod.js");
-  hooks:
-  fixture:
-    class: MongoDFixture
-    mongod_options:
-      set_parameters:
-        enableTestCommands: 1
+      ssl: ''

--- a/test_suites_369/dbaas_decimal.yml
+++ b/test_suites_369/dbaas_decimal.yml
@@ -4,17 +4,26 @@ selector:
   roots:
   - jstests/decimal/*.js
   exclude_with_any_tags:
-  - requires_replication
-  - requires_sharding
+  # Tests that aren't testing specific behaviors of authentication or authorization assume they are
+  # only ever being run with the __system user, which may not be compatible with the more
+  # restrictive permissions of a Database as a Service offering.
+  # https://docs.atlas.mongodb.com/reference/unsupported-commands-paid-tier-clusters/
+  - assumes_superuser_permissions
+  # The eval command is deprecated and isn't expected to be supported by Database as a Service
+  # offerings.
+  - requires_eval_command
+  # Tests that start their own MongoDB clusters using MongoRunner, ReplSetTest, or ShardingTest
+  # aren't meaningfully exercising anything about the Database as a Service offering.
+  - requires_spawning_own_processes
+  # Using the .host property of a Mongo connection object to establish a separate connection leads
+  # to omitting the auth+TLS connection string options.
+  - uses_multiple_connections
+  # Certains commands are only available when the testing mode of the server
+  # (`--setParameter enableTestCommands=1`) is enabled.
+  - uses_testing_only_commands
+
 executor:
-  archive:
-    hooks:
   config:
     shell_options:
       readMode: commands
-  hooks:
-  fixture:
-    class: MongoDFixture
-    mongod_options:
-      set_parameters:
-        enableTestCommands: 1
+      ssl: ''

--- a/test_suites_369/dbaas_json_schema.yml
+++ b/test_suites_369/dbaas_json_schema.yml
@@ -12,15 +12,9 @@ selector:
   - src/third_party/JSON-Schema-Test-Suite/tests/draft4/optional/zeroTerminatedFloats.json
   - src/third_party/JSON-Schema-Test-Suite/tests/draft4/ref.json
   - src/third_party/JSON-Schema-Test-Suite/tests/draft4/refRemote.json
+
 executor:
-  archive:
-    hooks:
   config:
     shell_options:
       readMode: commands
-  hooks:
-  fixture:
-    class: MongoDFixture
-    mongod_options:
-      set_parameters:
-        enableTestCommands: 1
+      ssl: ''


### PR DESCRIPTION
Changes the Dockerfile to fetch the v3.6.9-dbaas-testing branch of the mongodb/mongo repository.

----

**Disclaimer**: I only built the Docker image and ran the dbaas_decimal.yml test suite to verify my changes.